### PR TITLE
make bundle compatible with SSR

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'build'),
     filename: 'react-google-optimize.js',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   module: {
     rules: [


### PR DESCRIPTION
According to [Webpack's docs](https://webpack.js.org/configuration/output/#outputglobalobject):

> To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'.

Issue:
* https://stackoverflow.com/questions/49111086/webpack-4-universal-library-target
* https://github.com/webpack/webpack/issues/2875
* https://github.com/webpack/webpack/issues/6525